### PR TITLE
〈韓·中·日 電算學 用語 對照〉 카드 追加

### DIFF
--- a/assets/cards.json
+++ b/assets/cards.json
@@ -35,6 +35,13 @@
         "tags": ["Android", "韓國語"]
     },
     {
+        "emoji": "🖥️",
+        "title": "韓·中·日 電算學 用語 對照",
+        "description": "CJK computer science terms comparison.",
+        "href": "https://cjk-compsci-terms.netlify.app/",
+        "tags": ["韓國語", "日本語", "漢語"]
+    },
+    {
         "emoji": "➕",
         "title": "More",
         "description": "Contact the maintainer to add your project with 漢字.net subdomain.",


### PR DESCRIPTION
〈[韓·中·日 電算學 用語 對照][1]〉  카드를 追加했습니다.

![미리보기](https://user-images.githubusercontent.com/12431/179199218-71a7a4fe-5b2d-4fc6-af2e-f357b305788a.png)


[1]: https://cjk-compsci-terms.netlify.app/