### PR TITLE
國漢象會 (Mastodon) 카드 追加

### DIFF
--- a/assets/cards.json
+++ b/assets/cards.json
@@ -14,6 +14,13 @@
         "tags": ["Discord", "漢文"]
     },
     {
+        "emoji": "🐘",
+        "title": "國漢象會",
+        "description": "A Mastodon instance for Sino-Korean mixed script users.",
+        "href": "https://mastodon.韓國語.漢字.net/",
+        "tags": ["Mastodon", "韓國語"]
+    },
+    {
         "emoji": "🗺️",
         "title": "韓國語 地圖",
         "description": "An OpenStreetMap tile server with Hanja labels.",

--- a/assets/tag-styles.json
+++ b/assets/tag-styles.json
@@ -11,6 +11,10 @@
         "bg": "#E93C0C",
         "text": "white"
     },
+    "Mastodon": {
+        "bg": "#595aff",
+        "text": "white"
+    },
     "Wiki": {
         "bg": "#FBEFDB",
         "text": "black"


### PR DESCRIPTION
[國漢象會] (Mastodon) 카드를 追加했습니다.

![미리보기](https://user-images.githubusercontent.com/12431/202352571-4df38cdc-360f-4a53-a9fa-7697f7d7cffd.png)

[國漢象會]: https://mastodon.韓國語.漢字.net/